### PR TITLE
change fail12485.d to fail on very long symbols as before

### DIFF
--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -524,8 +524,8 @@ public:
     void toBuffer(const(char)* id, Dsymbol s)
     {
         size_t len = strlen(id);
-        if (buf.offset >= 8 * 1024 * 1024) // 8 megs ought be enough for anyone
-            s.error("excessive length %llu for symbol, possible recursive expansion?", len);
+        if (buf.offset + len >= 8 * 1024 * 1024) // 8 megs ought be enough for anyone
+            s.error("excessive length %llu for symbol, possible recursive expansion?", buf.offset + len);
         else
         {
             buf.printf("%u", cast(uint)len);

--- a/test/fail_compilation/fail12485.d
+++ b/test/fail_compilation/fail12485.d
@@ -1,11 +1,11 @@
 void dorecursive()
 {
-    recursive([0]);
+    recursive!"ratherLongSymbolNameToHitTheMaximumSymbolLengthEarlierThanTheTemplateRecursionLimit_";
 }
 
-void recursive(R)(R r)
+void recursive(string name)()
 {
-    import std.algorithm;
-    recursive( r.filter!(e=>true) );
+    struct S {} // define type to kick off mangler
+    recursive!(name ~ name);
 }
 


### PR DESCRIPTION
also fixes length output in the error message. The error message also includes the 8MB+ symbol, which isn't really helpful, but that hasn't changed from previous versions.